### PR TITLE
将后台md编辑器改为django-mdeditor  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+uwsgi_server
+
 # Created by .ignore support plugin (hsz.mobi)
 ### Python template
 # Byte-compiled / optimized / DLL files

--- a/apps/blog/models.py
+++ b/apps/blog/models.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.shortcuts import reverse
 import markdown
 import re
-
+from mdeditor.fields import MDTextField
 
 # Create your models here.
 
@@ -71,7 +71,7 @@ class Article(models.Model):
     author = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name='作者', on_delete=models.PROTECT)
     title = models.CharField(max_length=150, verbose_name='文章标题')
     summary = models.TextField('文章摘要', max_length=230, default='文章摘要等同于网页description内容，请务必填写...')
-    body = models.TextField(verbose_name='文章内容')
+    body = MDTextField(verbose_name='文章内容')
     img_link = models.CharField('图片地址', default=IMG_LINK, max_length=255)
     create_date = models.DateTimeField(verbose_name='创建时间', auto_now_add=True)
     update_date = models.DateTimeField(verbose_name='修改时间', auto_now=True)

--- a/izone/settings.py
+++ b/izone/settings.py
@@ -62,7 +62,6 @@ INSTALLED_APPS = [
     'allauth.socialaccount.providers.github',
 
     'rest_framework',
-    'mdeditor' # 添加markdown预览
 
     'crispy_forms',  # bootstrap表单样式
     'imagekit',  # 上传图片的应用
@@ -71,8 +70,10 @@ INSTALLED_APPS = [
     'blog',  # 博客应用
     'tool',  # 工具
     'comment',  # 评论
+
     'django_tctip',
 
+    'mdeditor' # 添加markdown预览,必须放在下面
 
 ]
 

--- a/izone/settings.py
+++ b/izone/settings.py
@@ -266,7 +266,7 @@ SITE_KEYWORDS = os.getenv('IZONE_SITE_KEYWORDS', 'izone,Django博客,个人博�
 
 # 个性化设置，非必要信息
 # 个人 Github 地址
-MY_GITHUB = os.getenv('IZONE_GITHUB', 'https://github.com/Hopetree')
+MY_GITHUB = os.getenv('IZONE_GITHUB', 'https://github.com/moyueheng')
 # 工信部备案信息
 BEIAN = os.getenv('IZONE_BEIAN', '网站备案信息')
 # 站长统计（友盟）

--- a/izone/settings.py
+++ b/izone/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
     'allauth.socialaccount.providers.github',
 
     'rest_framework',
+    'mdeditor' # 添加markdown预览
 
     'crispy_forms',  # bootstrap表单样式
     'imagekit',  # 上传图片的应用
@@ -71,6 +72,7 @@ INSTALLED_APPS = [
     'tool',  # 工具
     'comment',  # 评论
     'django_tctip',
+
 
 ]
 

--- a/izone/settings.py
+++ b/izone/settings.py
@@ -269,7 +269,7 @@ SITE_KEYWORDS = os.getenv('IZONE_SITE_KEYWORDS', 'izone,Django博客,个人博�
 
 # 个性化设置，非必要信息
 # 个人 Github 地址
-MY_GITHUB = os.getenv('IZONE_GITHUB', 'https://github.com/moyueheng')
+MY_GITHUB = os.getenv('IZONE_GITHUB', 'https://github.com/Hopetree')
 # 工信部备案信息
 BEIAN = os.getenv('IZONE_BEIAN', '网站备案信息')
 # 站长统计（友盟）

--- a/izone/urls.py
+++ b/izone/urls.py
@@ -41,6 +41,9 @@ urlpatterns = [
     path('robots.txt', robots, name='robots'), # robots
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'), # 网站地图
     path('feed/', AllArticleRssFeed(), name='rss'),   # rss订阅
+
+    path('mdeditor/', include('mdeditor.urls')) # meditor编辑器
+
 ]+ static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)  # 加入这个才能显示media文件
 
 if settings.API_FLAG:


### PR DESCRIPTION
将后台md编辑器改为django-mdeditor ，可以实现更加舒适流畅的编辑体验